### PR TITLE
fix: deleting uuid from metric cardinality

### DIFF
--- a/pkg/prometheus/prom.go
+++ b/pkg/prometheus/prom.go
@@ -39,7 +39,7 @@ var (
 			Name: "vault_injector_revoke_token_count_success",
 			Help: "Vault injector token revoked with success count",
 		},
-		[]string{"uuid", "namespace"},
+		[]string{"namespace"},
 	)
 	RevokeTokenErrorCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{

--- a/pkg/vault/handle_token.go
+++ b/pkg/vault/handle_token.go
@@ -385,7 +385,7 @@ func (c *Connector) RevokeOrphanToken(ctx context.Context, tokenId, uuid, namesp
 		c.Log.Errorf("error while revoking token: %v", err)
 		return err
 	}
-	promInjector.RevokeTokenCount.WithLabelValues(uuid, namespace).Inc()
+	promInjector.RevokeTokenCount.WithLabelValues(namespace).Inc()
 	promInjector.TokenExpirationInTime.DeleteLabelValues(uuid, namespace)
 	return nil
 }
@@ -397,7 +397,7 @@ func (c *Connector) RevokeSelfToken(ctx context.Context, tokenId, uuid, namespac
 		promInjector.RevokeTokenErrorCount.WithLabelValues(uuid, namespace).Inc()
 		c.Log.Errorf("error while revoking token: %v", err)
 	}
-	promInjector.RevokeTokenCount.WithLabelValues(uuid, namespace).Inc()
+	promInjector.RevokeTokenCount.WithLabelValues(namespace).Inc()
 	promInjector.TokenExpirationInTime.DeleteLabelValues(uuid, namespace)
 }
 


### PR DESCRIPTION
Remove uuid as it is not need for revoke operation on token