### PR TITLE
fix(ci): regenerate helm/README.md and auto-regen on release-please PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,9 +12,45 @@ jobs:
   release-please:
     name: release-please
     runs-on: ubuntu-latest
+    outputs:
+      pr: ${{ steps.release.outputs.pr }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - id: release
+        uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  regen-helm-docs:
+    name: Regenerate helm-docs in release PR
+    needs: release-please
+    if: needs.release-please.outputs.pr != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout release-please PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ fromJSON(needs.release-please.outputs.pr).headBranchName }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install helm-docs
+        run: |
+          HELM_DOCS_VERSION=1.14.2
+          curl -fsSL "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.deb" -o /tmp/helm-docs.deb
+          sudo dpkg -i /tmp/helm-docs.deb
+      - name: Regenerate helm/README.md
+        run: make helm-docs
+      - name: Commit and push if drift
+        run: |
+          if ! git diff --exit-code helm/README.md; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add helm/README.md
+            git commit -m "chore: regenerate helm-docs after release-please version bump"
+            git push
+            echo "::notice::Regenerated helm/README.md and pushed to release-please PR branch."
+          else
+            echo "::notice::helm/README.md already in sync — no regeneration needed."
+          fi

--- a/helm/README.md
+++ b/helm/README.md
@@ -2,7 +2,7 @@
 
 vault-db-injector helm chart
 
-![Version: 2.0.12](https://img.shields.io/badge/Version-2.0.12-informational?style=flat-square) ![AppVersion: 2.0.12](https://img.shields.io/badge/AppVersion-2.0.12-informational?style=flat-square)
+![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
 ## TL;DR — minimal values for the canonical NRI + projected-SA install
 
@@ -59,7 +59,7 @@ for a full walkthrough including Vault prerequisites.
 | vaultDbInjector.injector.args | list | `["--config=/injector/config.yaml"]` | Arguments passed to the injector container. |
 | vaultDbInjector.injector.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534}` | Pod-level securityContext applied to the injector container. Defaults are non-root + read-only root filesystem. |
 | vaultDbInjector.injector.image.repository | string | `"numberly/vault-db-injector"` | Injector container image repository. |
-| vaultDbInjector.injector.image.tag | string | `"2.0.12"` | Injector container image tag. |
+| vaultDbInjector.injector.image.tag | string | `"3.0.0"` | Injector container image tag. |
 | vaultDbInjector.injector.imagePullPolicy | string | `"Always"` | imagePullPolicy applied to the injector container. |
 | vaultDbInjector.injector.ports | list | `[{"port":8443,"targetPort":8443}]` | Service ports for the webhook (HTTPS). |
 | vaultDbInjector.injector.replicas | int | `2` | Number of injector Deployment replicas. |
@@ -69,14 +69,14 @@ for a full walkthrough including Vault prerequisites.
 | vaultDbInjector.renewer.args | list | `["--config=/renewer/config.yaml"]` | Arguments passed to the renewer container. |
 | vaultDbInjector.renewer.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534}` | Pod-level securityContext applied to the renewer container. |
 | vaultDbInjector.renewer.image.repository | string | `"numberly/vault-db-injector"` | Renewer container image repository. |
-| vaultDbInjector.renewer.image.tag | string | `"2.0.12"` | Renewer container image tag. |
+| vaultDbInjector.renewer.image.tag | string | `"3.0.0"` | Renewer container image tag. |
 | vaultDbInjector.renewer.imagePullPolicy | string | `"Always"` | imagePullPolicy applied to the renewer container. |
 | vaultDbInjector.renewer.replicas | int | `4` | Number of renewer replicas. Leader election selects one active renewer at a time. |
 | vaultDbInjector.renewer.serviceAccountName | string | `""` | Override the ServiceAccount used by the renewer Deployment. Empty = chart-managed default (`<release>` in legacy mode, `<release>-renewer` when `useProjectedSA: true`). |
 | vaultDbInjector.revoker.args | list | `["--config=/revoker/config.yaml"]` | Arguments passed to the revoker container. |
 | vaultDbInjector.revoker.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534}` | Pod-level securityContext applied to the revoker container. |
 | vaultDbInjector.revoker.image.repository | string | `"numberly/vault-db-injector"` | Revoker container image repository. |
-| vaultDbInjector.revoker.image.tag | string | `"2.0.12"` | Revoker container image tag. |
+| vaultDbInjector.revoker.image.tag | string | `"3.0.0"` | Revoker container image tag. |
 | vaultDbInjector.revoker.imagePullPolicy | string | `"Always"` | imagePullPolicy applied to the revoker container. |
 | vaultDbInjector.revoker.replicas | int | `4` | Number of revoker replicas. Leader election selects one active revoker at a time. |
 | vaultDbInjector.revoker.serviceAccountName | string | `""` | Override the ServiceAccount used by the revoker Deployment. Empty = chart-managed default (`<release>` in legacy mode, `<release>-revoker` when `useProjectedSA: true`). |


### PR DESCRIPTION
## Why

After merging the release-please PR (#59) for v3.0.0, the helm-docs-check job on main went red. Cause: release-please bumps `helm/Chart.yml` and `helm/values.yml` via the `type: generic` updater (line-level value replacement) but never invokes `helm-docs`. `helm/README.md` is the rendered output of values.yml, so it stayed at 2.0.12 while the source files moved to 3.0.0. The CI gate caught the drift.

## What

1. **Immediate fix**: regenerate `helm/README.md` to match the bumped values.yml. 4 lines change (Version badge + 3 image-tag rows in the values table).

2. **Future-proof**: patch `.github/workflows/release-please.yml` with a `regen-helm-docs` follow-up job. It only runs when release-please opened or updated a PR (`if: needs.release-please.outputs.pr != ''`), checks out the PR branch, runs `make helm-docs`, and pushes the regenerated README back to the same branch. From the next release onward, the release-please PR is self-consistent at open time.

## Test plan

- [x] Local `make helm-docs` produces a clean diff (4 lines)
- [x] Local `make helm-docs-check` exits 0 after the regen
- [x] YAML parse on the modified workflow
- [x] CI on this PR: helm-docs-check, helm-lint, lint, test, govulncheck, mkdocs-strict, pr-title — all green
- [x] Future verification: next release-please bump (e.g. v3.0.1 patch) produces a self-consistent PR