### PR TITLE
fix(release): publish v3.2.1 to ghcr.io and align chart defaults

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,12 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
       - "v[0-9]+.[0-9]+.[0-9]+-*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing git tag to (re)publish (e.g. v3.2.1)"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -26,9 +32,15 @@ jobs:
       is-prerelease: ${{ steps.version.outputs.is-prerelease }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
       - id: version
         run: |
-          VERSION="${GITHUB_REF#refs/tags/}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.tag }}"
+          else
+            VERSION="${GITHUB_REF#refs/tags/}"
+          fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           if [[ "${VERSION}" == *-* ]]; then
             echo "is-prerelease=true" >> "$GITHUB_OUTPUT"
@@ -83,6 +95,8 @@ jobs:
       packages: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
       - name: Run Trivy
         uses: aquasecurity/trivy-action@v0.36.0
         with:
@@ -152,6 +166,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ inputs.tag || github.ref }}
       - name: Configure git
         run: |
           git config user.name "$GITHUB_ACTOR"
@@ -181,6 +196,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
       - uses: azure/setup-helm@v4
         with:
           version: v3.16.4
@@ -215,7 +232,7 @@ jobs:
       - name: Append verification commands
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ inputs.tag || github.ref_name }}
           REPO: ${{ github.repository }}
         run: |
           BODY=$(gh release view "${TAG}" --repo "${REPO}" --json body --jq '.body')

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ helm install vault-db-injector numberly/vault-db-injector \
 ```bash
 helm install vault-db-injector \
   oci://ghcr.io/numberly/charts/vault-db-injector \
-  --version 3.0.0 \
+  --version 3.2.1 \
   --namespace vault-db-injector --create-namespace \
   -f my-values.yaml
 ```
@@ -89,13 +89,13 @@ helm install vault-db-injector \
 ### Container image
 
 ```bash
-docker pull ghcr.io/numberly/vault-db-injector:v3.0.0
+docker pull ghcr.io/numberly/vault-db-injector:v3.2.1
 ```
 
 The image is signed with Cosign keyless. Verify before deployment:
 
 ```bash
-cosign verify ghcr.io/numberly/vault-db-injector:v3.0.0 \
+cosign verify ghcr.io/numberly/vault-db-injector:v3.2.1 \
   --certificate-identity-regexp="^https://github.com/numberly/vault-db-injector/.github/workflows/release.yml@refs/tags/v[0-9].*$" \
   --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
 ```

--- a/docs/operators/migration-v2-to-v3.fr.md
+++ b/docs/operators/migration-v2-to-v3.fr.md
@@ -295,7 +295,7 @@ déploiement de la v3.0 ; c'est attendu).
 ```bash
 helm upgrade <release> ./helm/ \
   --reuse-values \
-  --version 3.0.0
+  --version 3.2.1
 ```
 
 Les valeurs par défaut conservent :

--- a/docs/operators/migration-v2-to-v3.md
+++ b/docs/operators/migration-v2-to-v3.md
@@ -298,7 +298,7 @@ deployed; that's expected).
 ```bash
 helm upgrade <release> ./helm/ \
   --reuse-values \
-  --version 3.0.0
+  --version 3.2.1
 ```
 
 Default values keep:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/numberly/vault-db-injector
 
-go 1.26.0
+go 1.26.4
 
 require (
 	github.com/cockroachdb/errors v1.13.0

--- a/helm/README.md
+++ b/helm/README.md
@@ -62,7 +62,7 @@ for a full walkthrough including Vault prerequisites.
 | vaultDbInjector.configuration.webhookMatchLabels | string | `"vault-db-injector"` | Value of the `objectSelector` label on the MutatingWebhookConfiguration. Pods carrying this label are sent to the webhook for admission. |
 | vaultDbInjector.injector.args | list | `["--config=/injector/config.yaml"]` | Arguments passed to the injector container. |
 | vaultDbInjector.injector.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534}` | Pod-level securityContext applied to the injector container. Defaults are non-root + read-only root filesystem. |
-| vaultDbInjector.injector.image.repository | string | `"numberly/vault-db-injector"` | Injector container image repository. |
+| vaultDbInjector.injector.image.repository | string | `"ghcr.io/numberly/vault-db-injector"` | Injector container image repository. |
 | vaultDbInjector.injector.image.tag | string | `"3.2.1"` | Injector container image tag. |
 | vaultDbInjector.injector.imagePullPolicy | string | `"Always"` | imagePullPolicy applied to the injector container. |
 | vaultDbInjector.injector.ports | list | `[{"port":8443,"targetPort":8443}]` | Service ports for the webhook (HTTPS). |
@@ -72,14 +72,14 @@ for a full walkthrough including Vault prerequisites.
 | vaultDbInjector.injector.type | string | `"ClusterIP"` | Service type for the webhook service. |
 | vaultDbInjector.renewer.args | list | `["--config=/renewer/config.yaml"]` | Arguments passed to the renewer container. |
 | vaultDbInjector.renewer.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534}` | Pod-level securityContext applied to the renewer container. |
-| vaultDbInjector.renewer.image.repository | string | `"numberly/vault-db-injector"` | Renewer container image repository. |
+| vaultDbInjector.renewer.image.repository | string | `"ghcr.io/numberly/vault-db-injector"` | Renewer container image repository. |
 | vaultDbInjector.renewer.image.tag | string | `"3.2.1"` | Renewer container image tag. |
 | vaultDbInjector.renewer.imagePullPolicy | string | `"Always"` | imagePullPolicy applied to the renewer container. |
 | vaultDbInjector.renewer.replicas | int | `4` | Number of renewer replicas. Leader election selects one active renewer at a time. |
 | vaultDbInjector.renewer.serviceAccountName | string | `""` | Override the ServiceAccount used by the renewer Deployment. Empty = chart-managed default (`<release>` in legacy mode, `<release>-renewer` when `useProjectedSA: true`). |
 | vaultDbInjector.revoker.args | list | `["--config=/revoker/config.yaml"]` | Arguments passed to the revoker container. |
 | vaultDbInjector.revoker.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534}` | Pod-level securityContext applied to the revoker container. |
-| vaultDbInjector.revoker.image.repository | string | `"numberly/vault-db-injector"` | Revoker container image repository. |
+| vaultDbInjector.revoker.image.repository | string | `"ghcr.io/numberly/vault-db-injector"` | Revoker container image repository. |
 | vaultDbInjector.revoker.image.tag | string | `"3.2.1"` | Revoker container image tag. |
 | vaultDbInjector.revoker.imagePullPolicy | string | `"Always"` | imagePullPolicy applied to the revoker container. |
 | vaultDbInjector.revoker.replicas | int | `4` | Number of revoker replicas. Leader election selects one active revoker at a time. |

--- a/helm/values.yml
+++ b/helm/values.yml
@@ -51,7 +51,7 @@ vaultDbInjector:
       runAsUser: 65534
     image:
       # -- Injector container image repository.
-      repository: numberly/vault-db-injector
+      repository: ghcr.io/numberly/vault-db-injector
       # -- Injector container image tag.
       tag: 3.2.1  # x-release-please-version
     # -- imagePullPolicy applied to the injector container.
@@ -84,7 +84,7 @@ vaultDbInjector:
     replicas: 4
     image:
       # -- Renewer container image repository.
-      repository: numberly/vault-db-injector
+      repository: ghcr.io/numberly/vault-db-injector
       # -- Renewer container image tag.
       tag: 3.2.1  # x-release-please-version
     # -- imagePullPolicy applied to the renewer container.
@@ -106,7 +106,7 @@ vaultDbInjector:
     replicas: 4
     image:
       # -- Revoker container image repository.
-      repository: numberly/vault-db-injector
+      repository: ghcr.io/numberly/vault-db-injector
       # -- Revoker container image tag.
       tag: 3.2.1  # x-release-please-version
     # -- imagePullPolicy applied to the revoker container.


### PR DESCRIPTION
## Summary

Closes #68 and fixes the root causes that left v3.x undeployable from
`ghcr.io`.

- **fix(helm)**: chart `image.repository` default for injector / renewer /
  revoker now resolves to `ghcr.io/numberly/vault-db-injector`. The previous
  bare `numberly/vault-db-injector` resolved to Docker Hub, which is frozen
  at `2.0.15`, so a default `helm install` of the v3 chart pulled a tag that
  never existed.
- **docs**: `README.md`, `migration-v2-to-v3.md`, and the FR variant now use
  `v3.2.1` in the install/verify snippets. The Docker Hub deprecation
  notice keeps the `v3.0.0` anchor (historical statement).
- **ci(release)**: add `workflow_dispatch` with a `tag` input. `release.yml`
  has been dormant since the `v3.0.0-rc.1` failure because `release-please`
  tags use `secrets.GITHUB_TOKEN`, which by design does not cascade into
  other workflows. The dispatch lets a maintainer re-run for an existing
  tag without retagging. All `actions/checkout` steps + the version
  derivation + the release-notes augmentation now read `inputs.tag` first
  and fall back to `github.ref` for tag-push runs.

## Follow-up after merge

```bash
gh workflow run release.yml --ref v3.2.1 -f tag=v3.2.1
gh run watch
```

If Trivy fails on the produced image, document each non-fixable CVE in
`.trivyignore` and re-trigger.

### Out of scope (separate PR + manual)

- Make the chart OCI package public:
  https://github.com/orgs/numberly/packages/container/charts%2Fvault-db-injector/settings
- Switch `release-please.yml` to a PAT / GitHub App token so future
  release-please tags cascade into `release.yml` automatically.

## Test plan

- [ ] `helm template t helm | grep 'image:'` shows `ghcr.io/numberly/vault-db-injector:3.2.1` (×3) and the NRI image inheriting the same.
- [ ] `helm lint helm` passes.
- [ ] CI gate (existing `ci.yml`) stays green.
- [ ] After merge, `gh workflow run release.yml --ref v3.2.1 -f tag=v3.2.1` succeeds end to end and publishes `ghcr.io/numberly/vault-db-injector:{v3.2.1,latest}` + the OCI chart.
- [ ] Unauthenticated `docker pull ghcr.io/numberly/vault-db-injector:v3.2.1` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)