### PR TITLE
fix(release): stop deleting the package version that holds stable tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,26 +135,16 @@ jobs:
           docker buildx imagetools create \
             -t "ghcr.io/numberly/vault-db-injector:latest" \
             "ghcr.io/numberly/vault-db-injector:${VERSION}-unsigned"
-      - name: Delete the transient :VERSION-unsigned tag
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ needs.build-image.outputs.version }}
-        run: |
-          PACKAGE_TYPE=container
-          PACKAGE_NAME=vault-db-injector
-          ORG=numberly
-          VID=$(gh api -H "Accept: application/vnd.github+json" \
-            "/orgs/${ORG}/packages/${PACKAGE_TYPE}/${PACKAGE_NAME}/versions" \
-            --paginate \
-            --jq ".[] | select(.metadata.container.tags[]? == \"${VERSION}-unsigned\") | .id" \
-            | head -1)
-          if [ -n "${VID}" ]; then
-            gh api -X DELETE -H "Accept: application/vnd.github+json" \
-              "/orgs/${ORG}/packages/${PACKAGE_TYPE}/${PACKAGE_NAME}/versions/${VID}"
-            echo "Deleted package version ${VID} that held tag ${VERSION}-unsigned"
-          else
-            echo "No package version found holding tag ${VERSION}-unsigned (already deleted?)"
-          fi
+      # NOTE: we intentionally do NOT delete the :VERSION-unsigned tag.
+      # On GHCR, `docker buildx imagetools create -t VERSION VERSION-unsigned`
+      # does not produce a new package version — it just attaches the
+      # `VERSION` (and `latest`) tag to the existing version that already
+      # carries `VERSION-unsigned`. The GHCR REST API has no per-tag
+      # deletion; `DELETE /packages/.../versions/{id}` removes the whole
+      # package version, which wipes the stable tags we just promoted.
+      # Leaving the `-unsigned` tag in place on the same version is the
+      # least-bad option and is consistent: it is literally the same
+      # image bytes that VERSION and latest point to.
 
   chart-releaser:
     name: Publish chart to gh-pages


### PR DESCRIPTION
## Why v3.2.2 / latest never landed on GHCR

The run dispatched on `v3.2.2` (Promote to stable tag job) succeeded
according to the logs:

```
pushing sha256:3db6f8a22863… to ghcr.io/numberly/vault-db-injector:v3.2.2
pushing sha256:3db6f8a22863… to ghcr.io/numberly/vault-db-injector:latest
Deleted package version 915843407 that held tag v3.2.2-unsigned
```

But anonymous pulls return 404 and the GHCR UI shows no `v3.2.2`, no
`latest`, only orphan per-platform child manifests and the cosign
`.sig`.

Root cause:

- `docker buildx imagetools create -t NEWTAG OLDTAG` on GHCR does **not**
  create a new package version. It attaches `NEWTAG` to the existing
  version that already carries `OLDTAG`. So after the two
  `imagetools create` calls, package version 915843407 held the tags
  `[v3.2.2-unsigned, v3.2.2, latest]`.
- The GHCR REST API has no per-tag deletion. The cleanup step does
  `DELETE /packages/.../versions/915843407` to drop the
  `-unsigned` tag — and removes the **entire** version, wiping `v3.2.2`
  and `latest` with it. The multi-arch index manifest itself is also
  deleted, which is why only the platform-specific child manifests
  remain in the UI.

## Fix

Drop the cleanup step. The `-unsigned` tag now stays attached to the
same package version as the stable `v3.2.2` + `latest` tags. They are
all literally the same image bytes, so the extra label is cosmetic at
worst.

## Follow-up after merge

```bash
gh workflow run release.yml --ref v3.2.2 -f tag=v3.2.2
gh run watch
```

Once green:

```bash
docker logout ghcr.io
docker pull ghcr.io/numberly/vault-db-injector:v3.2.2
docker pull ghcr.io/numberly/vault-db-injector:latest
```

## Out of scope (separate PRs)

- `chart-oci-push` → `Sign chart by digest` fails with GHCR
  `UNAUTHORIZED`: cosign doesn't pick up `helm registry login` creds.
  Add a `docker/login-action@v3` (or `COSIGN_REGISTRY_USER` /
  `COSIGN_REGISTRY_PASSWORD`) before the `cosign sign` call.
- `chart-releaser` → `latest_tag: unbound variable` from `cr.sh` v1.7.0
  on `workflow_dispatch` (no tag ref). Likely fixable by upgrading
  `helm/chart-releaser-action`.
- `release-please.yml` → swap `secrets.GITHUB_TOKEN` for a PAT/GitHub
  App so future release-please tags trigger `release.yml`
  automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)