### PR TITLE
fix(release): make chart publishing jobs succeed end-to-end

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,7 +169,15 @@ jobs:
           mkdir -p .cr-release-packages
           helm package helm -d .cr-release-packages
           ls -la .cr-release-packages
-      - uses: helm/chart-releaser-action@v1.7.0
+      # Pinned to the post-v1.7.0 main commit that ships #202
+      # ("Write chart_version only if latest_tag is defined"). The v1.7.0
+      # tag dereferences `latest_tag` unconditionally under `set -u`, which
+      # crashes any run that uses skip_packaging: true (our case — we
+      # pre-package above) with `cr.sh: line 111: latest_tag: unbound
+      # variable`, even after the chart and gh-pages index have been
+      # pushed successfully. Repin to a tagged release once one is cut
+      # past v1.7.0.
+      - uses: helm/chart-releaser-action@3e001cb8c68933439c7e721650f20a07a1a5c61e
         with:
           charts_dir: helm
           skip_packaging: true
@@ -192,7 +200,17 @@ jobs:
         with:
           version: v3.16.4
       - uses: sigstore/cosign-installer@v3
-      - name: Log in to GHCR
+      # cosign reads ~/.docker/config.json, which `helm registry login`
+      # does not populate. Without docker/login-action the `cosign sign`
+      # step further down fails with `UNAUTHORIZED: User cannot be
+      # authenticated with the token provided`.
+      - name: Log in to GHCR (docker auth for cosign)
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to GHCR (helm auth for push)
         run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u "${{ github.actor }}" --password-stdin
       - name: Package and push chart
         id: push


### PR DESCRIPTION
## Context

After PR #76 + #78 the image side of `release.yml` is green and
`v3.2.2` / `latest` are pullable from `ghcr.io`. Two chart-publishing
jobs are still failing on the same dispatched run, even though their
artefacts have actually shipped:

- `chart-oci-push` — the chart is **pushed** to
  `oci://ghcr.io/numberly/charts/vault-db-injector:3.2.2`, but the
  follow-up cosign sign step exits 1 with `UNAUTHORIZED`.
- `chart-releaser` — gh-pages `index.yaml` is **updated** with 3.2.2,
  but the action exits 1 with `cr.sh: line 111: latest_tag: unbound
  variable`.

The downstream `augment-release-notes` job is skipped as a result.

## Fixes

### 1. cosign auth in `chart-oci-push`

`cosign sign` reads `~/.docker/config.json`. The step before only ran
`helm registry login`, which populates helm's own keystore and not
docker's. Add `docker/login-action@v3` so cosign picks up GHCR creds.
Keep the helm login because the `helm push` step needs it.

### 2. chart-releaser v1.7.0 + `skip_packaging: true`

`cr.sh` declares `local latest_tag` only inside the
`if [[ -z "$skip_packaging" ]]` branch, then unconditionally writes
`chart_version=${latest_tag}` at the end of `main()`. Under `set -u`
this dies after the gh-pages push has already succeeded. The upstream
fix (`#202 — Write chart_version only if latest_tag is defined`) was
merged to main on 2025-01-20 but has not been retagged. Pin the action
to that commit SHA (`3e001cb8c68933439c7e721650f20a07a1a5c61e`) and
leave a comment to re-pin to a tag once one ships.

## Verification after merge

```bash
gh workflow run release.yml --ref main -f tag=v3.2.2
gh run watch
```

Expected: every job `success`, including `augment-release-notes`.

```bash
# Chart OCI: signature now present alongside the chart manifest
cosign verify ghcr.io/numberly/charts/vault-db-injector:3.2.2 \\
  --certificate-identity-regexp="^https://github.com/numberly/vault-db-injector/.github/workflows/release.yml@refs/(tags/v|heads/main).*\$" \\
  --certificate-oidc-issuer="https://token.actions.githubusercontent.com"

# Helm via gh-pages
helm repo add numberly https://numberly.github.io/vault-db-injector
helm repo update
helm search repo numberly/vault-db-injector
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)