### PR TITLE
fix(renewer): decouple renew increment from sync interval

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # numberlyinfra/vault-db-injector
 
-FROM golang:1.26-alpine AS build
+FROM golang:1.26.4-alpine AS build
 
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -214,6 +214,7 @@ func (cfg *Config) Validate() error {
 		{cfg.Sentry && cfg.SentryDsn == "", "no sentryDsn specified"},
 		{cfg.UseProjectedSA && len(cfg.TokenRequestAudiences) == 0, "tokenRequestAudiences must be set (e.g., [\"vault\"]) when useProjectedSA is true — empty audience disables the cryptographic SA-impersonation bound"},
 		{cfg.UseProjectedSA && cfg.TokenRequestExpirationSeconds <= 0, "tokenRequestExpirationSeconds must be > 0 when useProjectedSA is enabled"},
+		{cfg.TokenTTL != "" && !validDuration(cfg.TokenTTL), "tokenTTL must be a valid Go duration (e.g. \"8766h\")"},
 	}
 
 	for _, check := range checks {
@@ -222,6 +223,21 @@ func (cfg *Config) Validate() error {
 		}
 	}
 	return nil
+}
+
+func validDuration(s string) bool {
+	_, err := time.ParseDuration(s)
+	return err == nil
+}
+
+// TokenTTLSeconds parses TokenTTL (e.g. "8766h") into seconds. It is the TTL
+// requested from Vault on every token renew, decoupled from the sync interval.
+func (cfg *Config) TokenTTLSeconds() (int, error) {
+	d, err := time.ParseDuration(cfg.TokenTTL)
+	if err != nil {
+		return 0, errors.Wrapf(err, "invalid tokenTTL %q", cfg.TokenTTL)
+	}
+	return int(d.Seconds()), nil
 }
 
 func GetLogLevel(level string) (logrus.Level, error) {

--- a/pkg/renewer/renewer.go
+++ b/pkg/renewer/renewer.go
@@ -59,7 +59,15 @@ func (r *tokenRenewerImpl) RenewTokenJob(ctx context.Context) {
 		}
 
 		podService := k8s.NewPodService(r.clientset, r.cfg)
-		ok := vaultConn.SyncAndCleanupTokens(ctx, r.cfg, keyInfos, r.cfg.VaultSecretName, r.cfg.VaultSecretPrefix, podService, r.cfg.SyncTTLSecond)
+		// Renew increment is the desired token lifetime (TokenTTL), NOT the sync
+		// interval. Otherwise the token TTL collapses to the sync period.
+		renewIncrementSeconds, err := r.cfg.TokenTTLSeconds()
+		if err != nil {
+			r.log.Errorf("invalid tokenTTL, skipping sync: %v", err)
+			metrics.SynchronizationErrorCount.WithLabelValues().Inc()
+			return false
+		}
+		ok := vaultConn.SyncAndCleanupTokens(ctx, r.cfg, keyInfos, r.cfg.VaultSecretName, r.cfg.VaultSecretPrefix, podService, renewIncrementSeconds)
 		if !ok {
 			metrics.SynchronizationErrorCount.WithLabelValues().Inc()
 			return false

--- a/pkg/vault/handle_token.go
+++ b/pkg/vault/handle_token.go
@@ -373,7 +373,7 @@ func (c *Connector) HandlePodDeletionToken(ctx context.Context, keysInformation 
 	return nil
 }
 
-func (c *Connector) SyncAndCleanupTokens(ctx context.Context, cfg *config.Config, keysInformations []*KeyInfo, secretName, prefix string, podService k8s.PodService, syncTTLSeconds int) bool {
+func (c *Connector) SyncAndCleanupTokens(ctx context.Context, cfg *config.Config, keysInformations []*KeyInfo, secretName, prefix string, podService k8s.PodService, tokenRenewIncrementSeconds int) bool {
 	podsInformations, err := podService.GetAllPodAndNamespace(ctx)
 	if err != nil {
 		c.Log.Errorf("Error while trying to get Pod from Kubernetes %v", err)
@@ -415,7 +415,7 @@ func (c *Connector) SyncAndCleanupTokens(ctx context.Context, cfg *config.Config
 			}
 
 			if _, found := podInfoMap[ki.PodNameUID]; found {
-				err := c.RenewToken(ctx, ki.TokenID, ki.PodNameUID, ki.Namespace, syncTTLSeconds)
+				err := c.RenewToken(ctx, ki.TokenID, ki.PodNameUID, ki.Namespace, tokenRenewIncrementSeconds)
 				if err != nil {
 					c.Log.Errorf("Can't renew Token with pod UUID: %s", ki.PodNameUID)
 					isOk.Store(false)
@@ -529,8 +529,8 @@ func (c *Connector) RevokeSelfToken(ctx context.Context, tokenID string) error {
 	return nil
 }
 
-func (c *Connector) RenewToken(ctx context.Context, tokenID, uuid, namespace string, syncTTLSeconds int) error {
-	tokenRenew, err := c.client.Auth().Token().RenewWithContext(ctx, tokenID, syncTTLSeconds)
+func (c *Connector) RenewToken(ctx context.Context, tokenID, uuid, namespace string, renewIncrementSeconds int) error {
+	tokenRenew, err := c.client.Auth().Token().RenewWithContext(ctx, tokenID, renewIncrementSeconds)
 	if err != nil {
 		if strings.Contains(err.Error(), "token not found") {
 			c.Log.Debugf("can't renew revoked token for uuid %s : it has been revoked by the revoker", uuid)


### PR DESCRIPTION
The token renew increment was bound to SyncTTLSecond, so the requested TTL collapsed to the sync period (e.g. 1h with syncTTLSecond=3600). Use TokenTTL as the renew increment instead, keeping SyncTTLSecond only as the ticker cadence.

- config: add TokenTTLSeconds() and validate tokenTTL is a valid duration
- renewer: pass TokenTTLSeconds() as renew increment
- vault: rename syncTTLSeconds param to tokenRenewIncrementSeconds