### PR TITLE
fix(vault): revoke leaked technical tokens

### DIFF
--- a/pkg/k8smutator/k8smutator.go
+++ b/pkg/k8smutator/k8smutator.go
@@ -382,6 +382,24 @@ func injectCredentialsIntoPod(ctx context.Context, contextID string, cfg *config
 			vaultConn.K8sSaVaultToken = ""
 		}
 
+		// In projected-SA + NRI mode the webhook's per-admission pod-token
+		// (vaultConn.GetToken()) is used only for the authz Login above; the
+		// NRI plugin authenticates independently at CreateContainer time. It is
+		// never the parent of a credential lease here, so revoke it on the
+		// success path instead of letting it linger until token_max_ttl.
+		// NOTE: revoke GetToken() (the pod-token), NOT K8sSaVaultToken — the
+		// latter is the SHARED bookkeeping token owned by the cache.
+		if cfg.NRI.Enabled && cfg.UseProjectedSA {
+			if podTok := vaultConn.GetToken(); podTok != "" {
+				if revokeErr := vaultConn.RevokeSelfToken(ctx, podTok); revokeErr != nil {
+					logger.WithValues(log.Kv{"contextID": contextID}).Infof("RevokeSelfToken (projected-SA NRI admission pod-token) warning: %v", revokeErr)
+				}
+				// Clear so the deferred error cleanup (keyed on GetToken()) skips
+				// this already-revoked pod-token on a later multi-dbConfig failure.
+				vaultConn.SetToken("")
+			}
+		}
+
 		if creds != nil {
 			podUuids = append(podUuids, creds.PodUUID)
 		} else if cfg.NRI.Enabled {

--- a/pkg/renewer/renewer.go
+++ b/pkg/renewer/renewer.go
@@ -96,9 +96,14 @@ func (r *tokenRenewerImpl) RenewTokenJob(ctx context.Context) {
 			metrics.LastSynchronizationDuration.Observe(duration)
 
 		case <-r.stopChan:
-			if err := vaultConn.RevokeSelfToken(ctx, vaultConn.K8sSaVaultToken); err != nil {
+			// Use a fresh context: on SIGTERM the inherited ctx is already
+			// cancelled, which would make RevokeSelfToken fail immediately and
+			// leak the renewer's own login token. Mirrors revoker.go shutdown.
+			cleanupCtx, cancelCleanup := context.WithTimeout(context.Background(), 10*time.Second)
+			if err := vaultConn.RevokeSelfToken(cleanupCtx, vaultConn.K8sSaVaultToken); err != nil {
 				r.log.Errorf("RevokeSelfToken failed: %v", err)
 			}
+			cancelCleanup()
 			r.log.Warn("Stopping TokenSync1Hours due to lost leadership")
 			return
 		}

--- a/pkg/vault/handle_token.go
+++ b/pkg/vault/handle_token.go
@@ -613,12 +613,25 @@ func (c *Connector) StartTokenRenewal(ctx context.Context, cfg *config.Config) {
 				if err != nil {
 					c.Log.Errorf("Failed to renew Vault token: %v", err)
 					c.Log.Info("Trying to reconnect to Vault")
+					oldToken := c.K8sSaVaultToken
 					newConn, err := ConnectToVault(ctx, cfg, c.k8sSaToken)
 					if err != nil {
-						c.Log.Fatalf("Can't reconnect to VAULT: %v", err)
+						// Don't Fatalf: keep the current (stale) token and let the
+						// next tick retry. Killing the process here would abandon
+						// oldToken without revoking it.
+						c.Log.Errorf("Can't reconnect to VAULT, will retry next tick: %v", err)
+						continue
 					}
 					c.K8sSaVaultToken = newConn.K8sSaVaultToken
 					c.SetToken(newConn.K8sSaVaultToken)
+					// Revoke the abandoned login token so it doesn't linger until
+					// token_max_ttl. Best-effort: a failure here only delays cleanup
+					// to Vault-side expiry, it must not block renewal.
+					if oldToken != "" && oldToken != newConn.K8sSaVaultToken {
+						if revErr := c.RevokeSelfToken(ctx, oldToken); revErr != nil {
+							c.Log.Warnf("RevokeSelfToken (stale login token after reconnect) failed: %v", revErr)
+						}
+					}
 				}
 				c.Log.Debug("Token has been renewed succefully !")
 			}


### PR DESCRIPTION
## Contexte

Audit du cycle de vie des tokens Vault : accumulation de tokens **techniques** (login/auth) créés et jamais révoqués. Hors périmètre : les orphan/pod-tokens parents des leases de credentials DB, déjà trackés en KV et révoqués par le revoker.

## Fixes (atomiques)

1. **`fix(renewer): revoke abandoned login token on reconnect`** — `StartTokenRenewal` reconnectait via un nouveau login sans révoquer l'ancien token (1 fuite par échec de `RenewSelfToken`, jusqu'à `token_max_ttl`). On révoque l'ancien après bascule (best-effort) et on supprime le `log.Fatalf` sur échec de reconnexion (qui tuait le process en abandonnant le token courant) → retry au tick suivant. Concerne renewer **et** revoker.

2. **`fix(webhook): revoke admission pod-token in projected-SA NRI mode`** — en projected-SA + NRI, le pod-token d'admission ne sert qu'au check d'autorisation (le plugin NRI s'authentifie indépendamment au CreateContainer), n'est jamais parent de lease, et fuyait sur le chemin de succès. On le révoque après autz. Révoque `GetToken()` uniquement, **jamais** le token bookkeeping partagé (`K8sSaVaultToken`) — le révoquer provoquerait des 403 sur les admissions concurrentes. Blank du token pour éviter un double-revoke dans le cleanup d'erreur multi-dbConfig.

3. **`fix(renewer): revoke self token with fresh context on shutdown`** — au shutdown, le `ctx` hérité est déjà annulé par SIGTERM → `RevokeSelfToken` échouait immédiatement et fuyait le token du renewer. Contexte frais 10s, aligné sur `revoker.go`.

## Tests

- `go build ./...` ✅
- `go test ./pkg/vault/... ./pkg/k8smutator/... ./pkg/renewer/...` ✅ (90 tests)
- Revue de code (subagent senior) : invariant critique du token bookkeeping partagé prouvé respecté, aucun bug Critical.

## Suivi (hors scope)

- Data race pré-existant sur le connector partagé entre la goroutine `StartTokenRenewal` et la boucle `syncToken` (rendu plus atteignable par le retrait du `Fatalf`) → mutex sur le swap token/client à faire en issue séparée.
- Métriques d'observabilité (`vdbi_renewer_reconnect_count`, compteur de création de tokens).
