### PR TITLE
ci(release): trigger release.yml via GitHub App token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,10 +15,20 @@ jobs:
     outputs:
       pr: ${{ steps.release.outputs.pr }}
     steps:
+      # Mint a GitHub App token so the tag/release push is NOT attributed to
+      # the default GITHUB_TOKEN. Events triggered by GITHUB_TOKEN do not start
+      # new workflow runs (anti-recursion), which is why release.yml
+      # (on: push: tags) never fired on release-please releases. An App token
+      # is a distinct identity, so the tag push triggers release.yml normally.
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
       - id: release
         uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Problème

Après merge d'une PR release-please, le tag `vX.Y.Z` + la GitHub Release sont créés, mais le workflow **`Release`** (build/push image Docker, cosign, trivy, retag stable, charts) **ne se déclenche jamais**. L'image n'est donc jamais publiée (constaté sur `v3.2.4`).

## Cause racine

`release-please.yml` poussait le tag avec `secrets.GITHUB_TOKEN`. GitHub bloque volontairement la cascade : **un event produit par le `GITHUB_TOKEN` par défaut ne crée pas de nouveau run** (anti-récursion). Donc le `push` du tag n'armait pas le trigger `on: push: tags` de `release.yml`. L'équipe contournait jusqu'ici via `workflow_dispatch` manuel.

## Fix

Minter un **GitHub App token** (`actions/create-github-app-token@v1`) et le passer à release-please-action à la place de `GITHUB_TOKEN`. Un token d'App est une identité distincte → le push du tag déclenche `release.yml` normalement.

- `release.yml` **inchangé** : trigger `on: push: tags` et identité cosign keyless (`refs/tags/v*`) préservés.
- `regen-helm-docs` reste sur `GITHUB_TOKEN` (push sur branche de PR, pas de cascade tag requise).

## ⚠️ Prérequis avant merge (secrets)

Créer/réutiliser une **GitHub App** (perms repo `Contents: write` + `Pull requests: write`), l'installer sur le repo, et ajouter 2 secrets :
- `RELEASE_APP_ID`
- `RELEASE_APP_PRIVATE_KEY`

Sans ces secrets, le step `app-token` échouera.

## Vérification post-merge

1. Merger cette PR → release-please tourne avec le token d'App.
2. Couper la prochaine release (les fixes token-leak de v3.2.4 sont déjà sur `main`) → vérifier qu'un run `Release` démarre **automatiquement** : `gh run list --workflow=release.yml`.
3. `docker pull ghcr.io/numberly/vault-db-injector:<vX.Y.Z>` + tag `:latest`.
4. `cosign verify` avec l'identité `release.yml@refs/tags/v*` doit passer.
